### PR TITLE
Adding read/write settings to token permission documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ to [Create user-generated access tokens](https://www.dynatrace.com/support/help/
 
 Make sure the tokens have the following permissions:
 * API Token
+  * Read Settings
+  * Write Settings
   * Read Configuration
   * Write Configuration
   * Read Entities (if using automatic kubernetes api monitoring)


### PR DESCRIPTION
# Description
Updating README.md to include read/write settings for the API token as these are needed for kubernetes-monitoring.

## How can this be tested?
Not required, updating documentation only.